### PR TITLE
Add combined position_path field.

### DIFF
--- a/dashboard/config/mappings.json
+++ b/dashboard/config/mappings.json
@@ -44,6 +44,7 @@
         }
       },
 
+      "position_path" : { "type" : "string", "index": "not_analyzed" },
       "path" : { "type" : "string", "index": "not_analyzed" },
       "path1" : { "type" : "string", "index": "not_analyzed" },
       "path2" : { "type" : "string", "index": "not_analyzed" },

--- a/dashboard/fetch/ga.py
+++ b/dashboard/fetch/ga.py
@@ -582,6 +582,12 @@ class GAData(object):
                         'search': search,
                         'position': position,
                         'path': path,
+                        # Combined position_path field is used for facet
+                        # calculations; this is only needed because the
+                        # terms_stats facet doesn't allow a script to be used
+                        # for the key field - with elasticsearch 1.0
+                        # aggregations, this field wouldn't be needed.
+                        'position_path': "%04d%s" % (position, path),
                         'norm_search': norm_search,
                         'clicks': count,
                     }


### PR DESCRIPTION
The search dashboard stores a document for each combination of (search, document path, document rank), which holds a count of the number of times the document was clicked on.

The dashboard then performs a terms_stats facet (http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-facets-terms-stats-facet.html) to calculate the sum of the click counts for each document or for each position for a given search.  However, we can't calculate the sum of the click counts for the combination of each position and document, which is what I actually want to use.

This allows us to can calculate counts of number of times a result is
clicked on in a given position for a search.  Wouldn't be needed if we
were using elasticsearch 1.0+ aggregations which allow a script to be
used to calculate the key for this sort of operation.
