### PR TITLE
Return the actual paths clicked in the clicks API

### DIFF
--- a/dashboard/essearch.py
+++ b/dashboard/essearch.py
@@ -78,7 +78,7 @@ class ESSearch(object):
             'facets': {
                 'positions': {
                     'terms_stats': {
-                        'key_field': 'position',
+                        'key_field': 'position_path',
                         'value_field': 'clicks',
                         'order': 'term',
                         'size': 0,
@@ -90,13 +90,19 @@ class ESSearch(object):
             index=self.index,
             body=body
         )
-        positions = dict(
-            (item['term'], item['total'])
-            for item in result['facets']['positions']['terms']
-        )
+        positions = {}
+        for item in result['facets']['positions']['terms']:
+            term = item['term']
+            position = int(term[:4])
+            path = term[4:]
+            count = item['total']
+            positions.setdefault(position, []).append((path, item['total']))
         max_position = max(positions.keys())
         return [
-            (position, positions.get(position, 0))
+            (position,
+             sum(i[1] for i in positions.get(position, [])),
+             positions.get(position, []),
+            )
             for position in range(1, max_position + 1)
         ]
 

--- a/dashboard/serve.py
+++ b/dashboard/serve.py
@@ -54,7 +54,7 @@ def clicks():
     es = ESSearch()
     query = request.args.get('q', None)
     positions = es.click_positions(start_date(), end_date(), query=query)
-    counts = [count for (pos, count) in positions]
+    counts = [count for (pos, path_counts, count) in positions]
     return dict(
         positions=positions,
         total=sum(counts),


### PR DESCRIPTION
Instead of just returning the position and the number of clicks, also
return a list of [path, number of clicks] for each path that has had
results clicked on at that position.  When search results move around,
this is essential so that we know which search result actually got the
clicks.
